### PR TITLE
Move dev only deps to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@ledgerhq/hw-transport-u2f": "^5.34.0",
-        "@ledgerhq/hw-transport-webusb": "^5.34.1",
-        "@ledgerhq/logs": "^5.19.1",
-        "@waves/ts-lib-crypto": "^1.4.3",
-        "rimraf": "^3.0.2"
+        "@ledgerhq/logs": "^5.19.1"
       },
       "devDependencies": {
         "@babel/core": "^7.0.0-beta.54",
@@ -21,10 +18,13 @@
         "@babel/plugin-transform-runtime": "^7.0.0-beta.54",
         "@babel/preset-env": "^7.0.0-beta.54",
         "@babel/runtime": "^7.0.0-beta.54",
+        "@ledgerhq/hw-transport-webusb": "^5.34.1",
+        "@waves/ts-lib-crypto": "^1.4.3",
         "babel-runtime": "^6.26.0",
         "babelify": "^9.0.0",
         "browserify": "^16.2.3",
         "browserify-global-shim": "^1.0.3",
+        "rimraf": "^3.0.2",
         "typescript": "^3.9.6",
         "vinyl-buffer": "^1.0.1",
         "vinyl-source-stream": "^2.0.0"
@@ -905,6 +905,7 @@
       "version": "5.34.0",
       "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-5.34.0.tgz",
       "integrity": "sha512-oRoZDDfufXAv9KofQdOXc0QztISa9x/YVdiWs55iOlNRQjWYHSPFzeSP6+J+tN0Au/GS9v+wcnTf+tHCtVz27Q==",
+      "dev": true,
       "dependencies": {
         "@ledgerhq/errors": "^5.34.0",
         "@ledgerhq/logs": "^5.30.0",
@@ -914,17 +915,20 @@
     "node_modules/@ledgerhq/devices/node_modules/@ledgerhq/logs": {
       "version": "5.30.0",
       "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-5.30.0.tgz",
-      "integrity": "sha512-wUhg2VTfUrWihjdGqKkH/s7TBzdIM1yyd2LiscYsfTX2I0xYDMnpE+NkMReeGU8PN3QhCPgnlg9/P9V6UWoJBA=="
+      "integrity": "sha512-wUhg2VTfUrWihjdGqKkH/s7TBzdIM1yyd2LiscYsfTX2I0xYDMnpE+NkMReeGU8PN3QhCPgnlg9/P9V6UWoJBA==",
+      "dev": true
     },
     "node_modules/@ledgerhq/errors": {
       "version": "5.34.0",
       "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-5.34.0.tgz",
-      "integrity": "sha512-8Td60sOP5wzsjmxmj9Q5hjrr1XjCfB3Vdifq+1fiD6rpjyscYLgmoP2y5GYDPceDhalA/GOrKNSf+aIVVmBNOw=="
+      "integrity": "sha512-8Td60sOP5wzsjmxmj9Q5hjrr1XjCfB3Vdifq+1fiD6rpjyscYLgmoP2y5GYDPceDhalA/GOrKNSf+aIVVmBNOw==",
+      "dev": true
     },
     "node_modules/@ledgerhq/hw-transport": {
       "version": "5.34.0",
       "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-5.34.0.tgz",
       "integrity": "sha512-JxhqU9sBn+WH3CPMus9b70SED7LEeW17xw0VL5aRdxFu4YS5rhy5Xf4Sd5jIQfyDkHik1ouzfJVuQEju8+GGBw==",
+      "dev": true,
       "dependencies": {
         "@ledgerhq/devices": "^5.34.0",
         "@ledgerhq/errors": "^5.34.0",
@@ -996,6 +1000,7 @@
       "version": "5.34.1",
       "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-webusb/-/hw-transport-webusb-5.34.1.tgz",
       "integrity": "sha512-/hNUwNzjMlk7Fk8YrBqw2G9bbC7ahUVIrJqW+xop+Qgr9qrMv2QiHci+UJe3u9ITmG5BtVZF/R62Kfls8plKKA==",
+      "dev": true,
       "dependencies": {
         "@ledgerhq/devices": "^5.34.0",
         "@ledgerhq/errors": "^5.34.0",
@@ -1006,12 +1011,14 @@
     "node_modules/@ledgerhq/hw-transport-webusb/node_modules/@ledgerhq/logs": {
       "version": "5.30.0",
       "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-5.30.0.tgz",
-      "integrity": "sha512-wUhg2VTfUrWihjdGqKkH/s7TBzdIM1yyd2LiscYsfTX2I0xYDMnpE+NkMReeGU8PN3QhCPgnlg9/P9V6UWoJBA=="
+      "integrity": "sha512-wUhg2VTfUrWihjdGqKkH/s7TBzdIM1yyd2LiscYsfTX2I0xYDMnpE+NkMReeGU8PN3QhCPgnlg9/P9V6UWoJBA==",
+      "dev": true
     },
     "node_modules/@ledgerhq/hw-transport/node_modules/events": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
       "integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==",
+      "dev": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -1025,6 +1032,7 @@
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/@waves/ts-lib-crypto/-/ts-lib-crypto-1.4.3.tgz",
       "integrity": "sha512-2pKgyvtLapgM5vpaUEYzX7NYe2bkB+HdWn9W/4d7UFKwyg6zoOYhRQWyb6GuLi3OLHTETgiqpcMZvciFA0Ds6g==",
+      "dev": true,
       "dependencies": {
         "js-sha3": "^0.8.0",
         "node-forge": "^0.8.5"
@@ -1166,7 +1174,8 @@
     "node_modules/balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "node_modules/base64-js": {
       "version": "1.3.0",
@@ -1194,6 +1203,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1537,7 +1547,8 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "node_modules/concat-stream": {
       "version": "1.6.2",
@@ -1840,7 +1851,8 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -1858,6 +1870,7 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1959,6 +1972,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -1967,7 +1981,8 @@
     "node_modules/inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
     },
     "node_modules/inline-source-map": {
       "version": "0.6.2",
@@ -2032,7 +2047,8 @@
     "node_modules/js-sha3": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
+      "dev": true
     },
     "node_modules/js-tokens": {
       "version": "3.0.2",
@@ -2185,6 +2201,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -2249,6 +2266,7 @@
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
       "integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
+      "dev": true,
       "engines": {
         "node": ">= 4.5.0"
       }
@@ -2266,6 +2284,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -2315,6 +2334,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2561,6 +2581,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -2585,6 +2606,7 @@
       "version": "6.6.3",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
       "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
+      "dev": true,
       "dependencies": {
         "tslib": "^1.9.0"
       },
@@ -2967,7 +2989,8 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "node_modules/xtend": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -22,10 +22,7 @@
   },
   "dependencies": {
     "@ledgerhq/hw-transport-u2f": "^5.34.0",
-    "@ledgerhq/hw-transport-webusb": "^5.34.1",
-    "@ledgerhq/logs": "^5.19.1",
-    "@waves/ts-lib-crypto": "^1.4.3",
-    "rimraf": "^3.0.2"
+    "@ledgerhq/logs": "^5.19.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-beta.54",
@@ -33,10 +30,13 @@
     "@babel/plugin-transform-runtime": "^7.0.0-beta.54",
     "@babel/preset-env": "^7.0.0-beta.54",
     "@babel/runtime": "^7.0.0-beta.54",
+    "@ledgerhq/hw-transport-webusb": "^5.34.1",
+    "@waves/ts-lib-crypto": "^1.4.3",
     "babel-runtime": "^6.26.0",
     "babelify": "^9.0.0",
     "browserify": "^16.2.3",
     "browserify-global-shim": "^1.0.3",
+    "rimraf": "^3.0.2",
     "typescript": "^3.9.6",
     "vinyl-buffer": "^1.0.1",
     "vinyl-source-stream": "^2.0.0"


### PR DESCRIPTION
These dependencies are only used for build and/or running tests. They're not needed for published package to work, so it makes sense to move them from `dependencies` to `devDependencies`, so dependent projects won't have to install them unnecessarily.